### PR TITLE
Seed ID counters during graph deserialization

### DIFF
--- a/src/core/id.ts
+++ b/src/core/id.ts
@@ -20,3 +20,12 @@ export function reset_ids(seed?: Record<string, number>): void {
 		counters.set(prefix, value);
 	}
 }
+
+export function prime_ids(seed: Record<string, number>): void {
+	for (const [prefix, value] of Object.entries(seed)) {
+		const current = counters.get(prefix) ?? 0;
+		if (value > current) {
+			counters.set(prefix, value);
+		}
+	}
+}

--- a/src/core/serialize.ts
+++ b/src/core/serialize.ts
@@ -1,5 +1,6 @@
 import type { Edge, Graph, Node } from './types.js';
 import { add_node, connect, create_graph } from './graph.js';
+import { prime_ids } from './id.js';
 
 export interface Serialized_graph {
 	nodes: Node[];
@@ -14,6 +15,10 @@ export function serialize_graph(graph: Graph): Serialized_graph {
 }
 
 export function deserialize_graph(serialized: Serialized_graph): Graph {
+	const seeds = collect_id_seeds(serialized);
+	if (Object.keys(seeds).length > 0) {
+		prime_ids(seeds);
+	}
 	let graph = create_graph();
 	for (const node of serialized.nodes) {
 		graph = add_node(graph, clone_node(node));
@@ -42,4 +47,38 @@ function clone_edge(edge: Edge): Edge {
 		from: { ...edge.from },
 		to: { ...edge.to },
 	};
+}
+
+function collect_id_seeds(serialized: Serialized_graph): Record<string, number> {
+	const maxima = new Map<string, number>();
+	for (const node of serialized.nodes) {
+		record_max_suffix(maxima, node.id);
+	}
+	for (const edge of serialized.edges) {
+		record_max_suffix(maxima, edge.id);
+	}
+	return Object.fromEntries(maxima);
+}
+
+function record_max_suffix(target: Map<string, number>, id: string | undefined): void {
+	if (!id) {
+		return;
+	}
+	const separator = id.lastIndexOf('_');
+	if (separator === -1 || separator === id.length - 1) {
+		return;
+	}
+	const prefix = id.slice(0, separator);
+	const suffix = id.slice(separator + 1);
+	if (!/^[0-9a-z]+$/i.test(suffix)) {
+		return;
+	}
+	const value = parseInt(suffix, 36);
+	if (Number.isNaN(value)) {
+		return;
+	}
+	const current = target.get(prefix) ?? 0;
+	if (value > current) {
+		target.set(prefix, value);
+	}
 }

--- a/tests/graph.test.ts
+++ b/tests/graph.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { Node } from '../src/core/types.js';
-import { reset_ids } from '../src/core/id.js';
+import { gen_id, reset_ids } from '../src/core/id.js';
 import {
 	add_node,
 	connect,
@@ -127,4 +127,27 @@ describe('graph operations', () => {
 		const restored_node = restored.nodes.get('a');
 		expect(restored_node?.ports[0].node_id).toBe('a');
 	});
+	it('primes id counters from deserialized graphs', () => {
+		const node_a = make_node('n_1', [
+			{ id: 'n_1_out', node_id: 'n_1', side: 'right', kind: 'out', index: 0 },
+		]);
+		const node_b = make_node('n_2', [
+			{ id: 'n_2_in', node_id: 'n_2', side: 'left', kind: 'in', index: 0 },
+		]);
+		let graph = create_graph();
+		graph = add_node(graph, node_a);
+		graph = add_node(graph, node_b);
+		graph = connect(graph, {
+			from: { node_id: 'n_1', port_id: 'n_1_out' },
+			to: { node_id: 'n_2', port_id: 'n_2_in' },
+			id: 'e_1',
+		});
+		const serialized = serialize_graph(graph);
+		reset_ids();
+		const restored = deserialize_graph(serialized);
+		expect(restored.nodes.size).toBe(2);
+		expect(gen_id('n')).toBe('n_3');
+		expect(gen_id('e')).toBe('e_2');
+	});
+
 });


### PR DESCRIPTION
## Summary
- seed graph ID counters from serialized node and edge IDs before rebuilding the graph
- add an `prime_ids` helper so deserialization can update counters without clearing unrelated prefixes
- cover the regression with a test that ensures `gen_id` advances after deserialization

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e437c28d5883219954f5d4504ed655