### PR TITLE
Add command history manager for undo/redo

### DIFF
--- a/src/core/history.ts
+++ b/src/core/history.ts
@@ -1,0 +1,100 @@
+import type { Command, Graph } from './types.js';
+
+export interface Command_entry<R = unknown> {
+	command: Command<R>;
+	graph_before: Graph;
+	graph_after: Graph;
+	result?: R;
+}
+
+export interface History_state {
+	graph: Graph;
+	undo_stack: Command_entry[];
+	redo_stack: Command_entry[];
+}
+
+export interface Execute_result<R = unknown> {
+	history: History_state;
+	result?: R;
+}
+
+export function create_history(initial_graph: Graph): History_state {
+	return {
+		graph: initial_graph,
+		undo_stack: [],
+		redo_stack: [],
+	};
+}
+
+export function execute_command<R>(history: History_state, command: Command<R>): Execute_result<R> {
+	const { graph: graph_before } = history;
+	const { graph: graph_after, result } = command.do(graph_before);
+	const mutated = graph_after !== graph_before;
+	if (!mutated) {
+		return {
+			history: {
+				graph: graph_after,
+				undo_stack: history.undo_stack,
+				redo_stack: history.redo_stack,
+			},
+			result,
+		};
+	}
+	const entry: Command_entry<R> = {
+		command,
+		graph_before,
+		graph_after,
+		result,
+	};
+	return {
+		history: {
+			graph: graph_after,
+			undo_stack: [...history.undo_stack, entry],
+			redo_stack: [],
+		},
+		result,
+	};
+}
+
+export function undo(history: History_state): History_state {
+	if (!history.undo_stack.length) {
+		return history;
+	}
+	const next_undo_stack = history.undo_stack.slice(0, -1);
+	const entry = history.undo_stack[history.undo_stack.length - 1];
+	const previous_graph = entry.command.undo ? entry.command.undo(history.graph) : entry.graph_before;
+	return {
+		graph: previous_graph,
+		undo_stack: next_undo_stack,
+		redo_stack: [...history.redo_stack, entry],
+	};
+}
+
+export function redo(history: History_state): History_state {
+	if (!history.redo_stack.length) {
+		return history;
+	}
+	const next_redo_stack = history.redo_stack.slice(0, -1);
+	const entry = history.redo_stack[history.redo_stack.length - 1];
+	return {
+		graph: entry.graph_after,
+		undo_stack: [...history.undo_stack, entry],
+		redo_stack: next_redo_stack,
+	};
+}
+
+export function clear_history(history: History_state, graph: Graph): History_state {
+	return {
+		graph,
+		undo_stack: [],
+		redo_stack: [],
+	};
+}
+
+export function can_undo(history: History_state): boolean {
+	return history.undo_stack.length > 0;
+}
+
+export function can_redo(history: History_state): boolean {
+	return history.redo_stack.length > 0;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from './core/types.js';
 export * from './core/id.js';
 export * from './core/graph.js';
 export * from './core/serialize.js';
+export * from './core/history.js';

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Command, Node } from '../src/core/types.js';
+import { add_node, create_graph, remove_node, set_node_position } from '../src/core/graph.js';
+import {
+	can_redo,
+	can_undo,
+	clear_history,
+	create_history,
+	execute_command,
+	redo,
+	undo,
+} from '../src/core/history.js';
+
+function make_node(id: string): Node {
+	return {
+		id,
+		type: 'test',
+		x: 0,
+		y: 0,
+		ports: [],
+	};
+}
+
+describe('command history', () => {
+	let base_graph = create_graph();
+
+	beforeEach(() => {
+		base_graph = create_graph();
+	});
+
+	it('executes commands and tracks undo/redo stacks', () => {
+		let history = create_history(base_graph);
+		const node = make_node('node_a');
+		const command: Command<string> = {
+			type: 'add_node',
+			payload: node,
+			do(graph) {
+				const next = add_node(graph, node);
+				return { graph: next, result: node.id };
+			},
+			undo(graph) {
+				return remove_node(graph, node.id);
+			},
+		};
+		const executed = execute_command(history, command);
+		history = executed.history;
+		expect(executed.result).toBe('node_a');
+		expect(history.graph.nodes.has('node_a')).toBe(true);
+		expect(can_undo(history)).toBe(true);
+		expect(can_redo(history)).toBe(false);
+		history = undo(history);
+		expect(history.graph.nodes.size).toBe(0);
+		expect(can_undo(history)).toBe(false);
+		expect(can_redo(history)).toBe(true);
+		history = redo(history);
+		expect(history.graph.nodes.has('node_a')).toBe(true);
+		expect(can_redo(history)).toBe(false);
+	});
+
+	it('clears redo stack when executing a new command after undo', () => {
+		let history = create_history(base_graph);
+		const first_node = make_node('first');
+		const add_first: Command<void> = {
+			type: 'add_first',
+			do(graph) {
+				return { graph: add_node(graph, first_node) };
+			},
+			undo(graph) {
+				return remove_node(graph, first_node.id);
+			},
+		};
+		history = execute_command(history, add_first).history;
+		history = undo(history);
+		expect(can_redo(history)).toBe(true);
+		const second_node = make_node('second');
+		const add_second: Command<void> = {
+			type: 'add_second',
+			do(graph) {
+				return { graph: add_node(graph, second_node) };
+			},
+			undo(graph) {
+				return remove_node(graph, second_node.id);
+			},
+		};
+		history = execute_command(history, add_second).history;
+		expect(can_redo(history)).toBe(false);
+	});
+
+	it('skips recording entries when commands do not mutate the graph', () => {
+		let history = create_history(base_graph);
+		const noop_command: Command<void> = {
+			type: 'noop',
+			do(graph) {
+				return { graph };
+			},
+		};
+		const executed = execute_command(history, noop_command);
+		const next_history = executed.history;
+		expect(next_history.undo_stack.length).toBe(0);
+		expect(next_history.redo_stack.length).toBe(0);
+		expect(can_undo(next_history)).toBe(false);
+	});
+
+	it('clears stacks while replacing the tracked graph', () => {
+		let history = create_history(base_graph);
+		const node = make_node('to_replace');
+		history = execute_command(history, {
+			type: 'add',
+			do(graph) {
+				return { graph: add_node(graph, node) };
+			},
+			undo(graph) {
+				return remove_node(graph, node.id);
+			},
+		} as Command<void>).history;
+		expect(history.undo_stack.length).toBe(1);
+		const reset_graph = create_graph();
+		history = clear_history(history, reset_graph);
+		expect(history.graph).toBe(reset_graph);
+		expect(history.undo_stack.length).toBe(0);
+		expect(history.redo_stack.length).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary
- add a command history state container with undo/redo helpers around command execution
- export the history utilities from the library entry point
- cover the command stack workflows with new unit tests

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e43e57a4c08321a0ab0b643616f49f