### PR TITLE
feat: add React node layer with drag handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ ghlighted, and future milestones remain unchecked so contributors can anticipate
 3. [x] Graph state & operations
 4. [x] Command stack & history
 5. [x] Selection model
-6. [ ] **React adapter bootstrap** *(in progress — next up)*
-7. [ ] Node view & dragging
+6. [x] React adapter bootstrap
+7. [ ] **Node view & dragging** *(in progress — next up)*
 8. [ ] Ports & edge creation
 9. [ ] Edge routing (straight → quad curve)
 10. [ ] Keyboard layer
@@ -75,7 +75,7 @@ apter bootstrap, which unlocks the subsequent UI-facing milestones (node view/dr
 
 ## Next steps
 
-With the selection model in place, the upcoming milestone is the **React adapter bootstrap**, layering pan/zoom and rendering primitives on top of the headless core. Once that scaffolding lands, effort will move to **Node view & dragging** followed by **Ports & edge creation**, completing the interaction loop outlined in the roadmap.
+With the React adapter bootstrap in place, the next milestone is **Node view & dragging**, bringing interactive node surfaces to the canvas. After that, effort will move to **Ports & edge creation**, completing the interaction loop outlined in the roadmap.
 
 ## Automation roadmap
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,5 @@ export * from './core/graph.js';
 export * from './core/serialize.js';
 export * from './core/history.js';
 export * from './core/selection.js';
+export * from './react/camera.js';
+export * from './react/canvas.js';

--- a/src/react/camera.ts
+++ b/src/react/camera.ts
@@ -1,0 +1,88 @@
+export interface Camera_limits {
+	min_scale: number;
+	max_scale: number;
+}
+
+export interface Camera_state {
+	x: number;
+	y: number;
+	scale: number;
+}
+
+export interface Point {
+	x: number;
+	y: number;
+}
+
+export const DEFAULT_CAMERA_LIMITS: Camera_limits = {
+	min_scale: 0.25,
+	max_scale: 4,
+};
+
+export const DEFAULT_CAMERA_STATE: Camera_state = {
+	x: 0,
+	y: 0,
+	scale: 1,
+};
+
+export function clamp_scale(scale: number, limits: Camera_limits = DEFAULT_CAMERA_LIMITS): number {
+	return Math.min(limits.max_scale, Math.max(limits.min_scale, scale));
+}
+
+export function pan_camera(camera: Camera_state, dx: number, dy: number): Camera_state {
+	if (!dx && !dy) {
+		return camera;
+	}
+	return {
+		...camera,
+		x: camera.x + dx,
+		y: camera.y + dy,
+	};
+}
+
+export function zoom_camera(
+	camera: Camera_state,
+	target_scale: number,
+	pivot?: Point,
+	limits: Camera_limits = DEFAULT_CAMERA_LIMITS,
+): Camera_state {
+	const clamped = clamp_scale(target_scale, limits);
+	if (!pivot) {
+		if (clamped === camera.scale) {
+			return camera;
+		}
+		return {
+			...camera,
+			scale: clamped,
+		};
+	}
+	if (clamped === camera.scale) {
+		return camera;
+	}
+	const ratio = clamped / camera.scale;
+	const offset_x = pivot.x - camera.x;
+	const offset_y = pivot.y - camera.y;
+	return {
+		x: pivot.x - offset_x * ratio,
+		y: pivot.y - offset_y * ratio,
+		scale: clamped,
+	};
+}
+
+export function reset_camera(
+	camera: Camera_state,
+	fallback: Camera_state = DEFAULT_CAMERA_STATE,
+): Camera_state {
+	if (
+		camera.x === fallback.x &&
+		camera.y === fallback.y &&
+		camera.scale === fallback.scale
+	) {
+		return camera;
+	}
+	return {
+		x: fallback.x,
+		y: fallback.y,
+		scale: fallback.scale,
+	};
+}

--- a/src/react/canvas.tsx
+++ b/src/react/canvas.tsx
@@ -1,0 +1,306 @@
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
+import type { CSSProperties, JSX, PointerEvent as React_pointer_event, ReactNode } from 'react';
+import {
+	DEFAULT_CAMERA_LIMITS,
+	DEFAULT_CAMERA_STATE,
+	clamp_scale,
+	pan_camera,
+	zoom_camera,
+} from './camera.js';
+import type { Camera_limits, Camera_state, Point } from './camera.js';
+
+export interface Graph_viewport {
+	width: number;
+	height: number;
+}
+
+export interface Graph_camera_context_value {
+	camera: Camera_state;
+	viewport: Graph_viewport;
+	limits: Camera_limits;
+	set_camera: (next: Camera_state | ((current: Camera_state) => Camera_state)) => void;
+	reset_camera: () => void;
+}
+
+const Graph_camera_context = createContext<Graph_camera_context_value | null>(null);
+
+export function use_graph_camera(): Graph_camera_context_value {
+	const context = useContext(Graph_camera_context);
+	if (!context) {
+		throw new Error('Graph_camera_context missing. Wrap your tree in <Graph_canvas>.');
+	}
+	return context;
+}
+
+type Dom_global = typeof globalThis & Partial<Window & { ResizeObserver: typeof ResizeObserver }>;
+const dom_global = globalThis as Dom_global;
+const has_dom = typeof dom_global.document !== 'undefined';
+const use_isomorphic_layout_effect = has_dom ? useLayoutEffect : useEffect;
+
+
+interface Drag_state {
+	pointer_id: number;
+	origin: Point;
+	camera: Camera_state;
+}
+
+export interface Graph_canvas_props {
+	children?: ReactNode;
+	className?: string;
+	style?: CSSProperties;
+	min_scale?: number;
+	max_scale?: number;
+	initial_camera?: Partial<Camera_state>;
+	on_camera_change?: (camera: Camera_state) => void;
+}
+
+export function Graph_canvas(props: Graph_canvas_props): JSX.Element {
+	const {
+		children,
+		className,
+		style,
+		min_scale,
+		max_scale,
+		initial_camera,
+		on_camera_change,
+	} = props;
+	const resolved_limits = useMemo(() => {
+		const min = min_scale ?? DEFAULT_CAMERA_LIMITS.min_scale;
+		const max = max_scale ?? DEFAULT_CAMERA_LIMITS.max_scale;
+		if (min > max) {
+			return { min_scale: max, max_scale: min };
+		}
+		return { min_scale: min, max_scale: max };
+	}, [min_scale, max_scale]);
+	const limits_ref = useRef(resolved_limits);
+	useEffect(() => {
+		limits_ref.current = resolved_limits;
+	}, [resolved_limits]);
+	const initial_values = useMemo(() => {
+		const base = initial_camera ?? {};
+		const scale = clamp_scale(base.scale ?? DEFAULT_CAMERA_STATE.scale, resolved_limits);
+		return {
+			x: base.x ?? DEFAULT_CAMERA_STATE.x,
+			y: base.y ?? DEFAULT_CAMERA_STATE.y,
+			scale,
+		};
+	}, [initial_camera, resolved_limits]);
+	const initial_ref = useRef(initial_values);
+	const [camera, set_camera_state] = useState<Camera_state>(initial_values);
+	useEffect(() => {
+		initial_ref.current = initial_values;
+		set_camera_state((prev) => {
+			if (
+				prev.x === initial_values.x &&
+				prev.y === initial_values.y &&
+				prev.scale === initial_values.scale
+			) {
+				return prev;
+			}
+			return initial_values;
+		});
+	}, [initial_values]);
+	useEffect(() => {
+		set_camera_state((prev) => {
+			const clamped = clamp_scale(prev.scale, resolved_limits);
+			if (clamped === prev.scale) {
+				return prev;
+			}
+			return { ...prev, scale: clamped };
+		});
+	}, [resolved_limits]);
+	const container_ref = useRef<HTMLDivElement | null>(null);
+	const drag_ref = useRef<Drag_state | null>(null);
+	const [is_panning, set_is_panning] = useState(false);
+	const [viewport, set_viewport] = useState<Graph_viewport>({ width: 0, height: 0 });
+	use_isomorphic_layout_effect(() => {
+		if (!has_dom) {
+			return;
+		}
+		const element = container_ref.current;
+		if (!element) {
+			return;
+		}
+		const update = () => {
+			const rect = element.getBoundingClientRect();
+			set_viewport({ width: rect.width, height: rect.height });
+		};
+		update();
+		const Observer = dom_global.ResizeObserver;
+		if (!Observer) {
+			if (!dom_global.addEventListener || !dom_global.removeEventListener) {
+				return;
+			}
+			dom_global.addEventListener('resize', update);
+			return () => {
+				dom_global.removeEventListener?.('resize', update);
+			};
+		}
+		const observer = new Observer(() => update());
+		observer.observe(element);
+		return () => observer.disconnect();
+	}, []);
+	const set_camera = useCallback((next: Camera_state | ((current: Camera_state) => Camera_state)) => {
+		set_camera_state((prev) => {
+			const computed = typeof next === 'function' ? (next as (current: Camera_state) => Camera_state)(prev) : next;
+			if (
+				prev.x === computed.x &&
+				prev.y === computed.y &&
+				prev.scale === computed.scale
+			) {
+				return prev;
+			}
+			return computed;
+		});
+	}, []);
+	const reset = useCallback(() => {
+		const target = initial_ref.current;
+		set_camera_state((prev) => {
+			const scale = clamp_scale(target.scale, limits_ref.current);
+			if (
+				prev.x === target.x &&
+				prev.y === target.y &&
+				prev.scale === scale
+			) {
+				return prev;
+			}
+			return { x: target.x, y: target.y, scale };
+		});
+	}, []);
+	useEffect(() => {
+		if (!on_camera_change) {
+			return;
+		}
+		on_camera_change(camera);
+	}, [camera, on_camera_change]);
+	const handle_wheel = useCallback((event: WheelEvent) => {
+		if (!container_ref.current) {
+			return;
+		}
+		event.preventDefault();
+		const rect = container_ref.current.getBoundingClientRect();
+		const pivot: Point = {
+			x: event.clientX - rect.left,
+			y: event.clientY - rect.top,
+		};
+		const delta_scale = Math.exp(-event.deltaY * 0.001);
+		set_camera_state((prev) => {
+			const next_scale = prev.scale * delta_scale;
+			return zoom_camera(prev, next_scale, pivot, limits_ref.current);
+		});
+	}, []);
+	useEffect(() => {
+		const element = container_ref.current;
+		if (!element) {
+			return;
+		}
+		const listener = (event: WheelEvent) => handle_wheel(event);
+		element.addEventListener('wheel', listener, { passive: false });
+		return () => element.removeEventListener('wheel', listener);
+	}, [handle_wheel]);
+	const handle_pointer_down = useCallback((event: React_pointer_event<HTMLDivElement>) => {
+		if (event.button !== 0) {
+			return;
+		}
+		if (event.currentTarget !== event.target) {
+			return;
+		}
+		event.preventDefault();
+		event.currentTarget.setPointerCapture(event.pointerId);
+		drag_ref.current = {
+			pointer_id: event.pointerId,
+			origin: { x: event.clientX, y: event.clientY },
+			camera,
+		};
+		set_is_panning(true);
+	}, [camera]);
+	const handle_pointer_move = useCallback((event: React_pointer_event<HTMLDivElement>) => {
+		const drag = drag_ref.current;
+		if (!drag || drag.pointer_id !== event.pointerId) {
+			return;
+		}
+		event.preventDefault();
+		const dx = event.clientX - drag.origin.x;
+		const dy = event.clientY - drag.origin.y;
+		set_camera_state(() => pan_camera(drag.camera, dx, dy));
+	}, []);
+	const end_pan = useCallback(() => {
+		drag_ref.current = null;
+		set_is_panning(false);
+	}, []);
+	const handle_pointer_up = useCallback((event: React_pointer_event<HTMLDivElement>) => {
+		if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+			event.currentTarget.releasePointerCapture(event.pointerId);
+		}
+		if (drag_ref.current?.pointer_id === event.pointerId) {
+			end_pan();
+		}
+	}, [end_pan]);
+	const handle_pointer_cancel = useCallback(() => {
+		end_pan();
+	}, [end_pan]);
+	const handle_double_click = useCallback(() => {
+		reset();
+	}, [reset]);
+	const container_style: CSSProperties = {
+		position: 'relative',
+		overflow: 'hidden',
+		touchAction: 'none',
+		cursor: is_panning ? 'grabbing' : 'grab',
+		...style,
+	};
+	const content_style: CSSProperties = {
+		position: 'absolute',
+		top: 0,
+		left: 0,
+		width: '100%',
+		height: '100%',
+		transformOrigin: '0 0',
+		transform: `translate(${camera.x}px, ${camera.y}px) scale(${camera.scale})`,
+	};
+	const context_value = useMemo<Graph_camera_context_value>(() => ({
+		camera,
+		viewport,
+		limits: resolved_limits,
+		set_camera,
+		reset_camera: reset,
+	}), [camera, viewport, resolved_limits, set_camera, reset]);
+	return (
+		<div
+			ref={container_ref}
+			className={className}
+			style={container_style}
+			onPointerDown={handle_pointer_down}
+			onPointerMove={handle_pointer_move}
+			onPointerUp={handle_pointer_up}
+			onPointerLeave={handle_pointer_cancel}
+			onPointerCancel={handle_pointer_cancel}
+			onDoubleClick={handle_double_click}
+		>
+			<div style={content_style}>
+				<Graph_camera_context.Provider value={context_value}>
+					{children}
+				</Graph_camera_context.Provider>
+			</div>
+		</div>
+	);
+}
+
+export function use_graph_viewport(): Graph_viewport {
+	return use_graph_camera().viewport;
+}
+
+export function use_graph_limits(): Camera_limits {
+	return use_graph_camera().limits;
+}
+
+export type { Camera_state } from './camera.js';

--- a/src/react/nodes.tsx
+++ b/src/react/nodes.tsx
@@ -1,0 +1,269 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type { CSSProperties, JSX, PointerEvent as React_pointer_event, ReactNode } from 'react';
+import type { Node, Node_id } from '../core/types.js';
+import { use_graph_camera } from './canvas.js';
+import type { Point } from './camera.js';
+
+const DEFAULT_NODE_WIDTH = 180;
+const DEFAULT_NODE_HEIGHT = 104;
+
+export interface Graph_node_render_state {
+	selected: boolean;
+	dragging: boolean;
+}
+
+export interface Graph_node_drag_event<T = unknown> {
+	node_ids: Node_id[];
+	positions: Map<Node_id, Point>;
+	delta: Point;
+	nodes: Map<Node_id, Node<T>>;
+}
+
+export interface Graph_node_pointer_event<T = unknown> {
+	node: Node<T>;
+	pointer_event: React_pointer_event<HTMLDivElement>;
+}
+
+export interface Graph_node_layer_props<T = unknown> {
+	nodes: Node<T>[];
+	selected_ids?: ReadonlySet<Node_id>;
+	className?: string;
+	style?: CSSProperties;
+	default_width?: number;
+	default_height?: number;
+	render_node?: (node: Node<T>, state: Graph_node_render_state) => ReactNode;
+	on_node_pointer_down?: (event: Graph_node_pointer_event<T>) => void;
+	on_drag_start?: (event: Graph_node_drag_event<T>) => void;
+	on_drag?: (event: Graph_node_drag_event<T>) => void;
+	on_drag_end?: (event: Graph_node_drag_event<T>) => void;
+}
+
+interface Node_drag_state {
+	pointer_id: number;
+	origin: Point;
+	initial_positions: Map<Node_id, Point>;
+	target_ids: Node_id[];
+	scale: number;
+}
+
+export function compute_drag_positions(initial_positions: Map<Node_id, Point>, delta: Point): Map<Node_id, Point> {
+	const positions = new Map<Node_id, Point>();
+	for (const [id, origin] of initial_positions) {
+		positions.set(id, {
+			x: origin.x + delta.x,
+			y: origin.y + delta.y,
+		});
+	}
+	return positions;
+}
+
+function default_render_node<T>(node: Node<T>, state: Graph_node_render_state): ReactNode {
+	const surface_style: CSSProperties = {
+		width: '100%',
+		height: '100%',
+		borderRadius: 12,
+		background: state.selected ? '#eff6ff' : '#ffffff',
+		border: `1px solid ${state.selected ? '#2563eb' : '#e5e7eb'}`,
+		boxShadow: state.dragging ? '0 12px 30px rgba(15, 23, 42, 0.18)' : '0 2px 10px rgba(15, 23, 42, 0.08)',
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		fontSize: 14,
+		fontWeight: 600,
+		color: '#111827',
+		pointerEvents: 'none',
+		userSelect: 'none',
+	};
+	return <div style={surface_style}>{node.type}</div>;
+}
+
+export function Graph_node_layer<T>(props: Graph_node_layer_props<T>): JSX.Element {
+	const {
+		nodes,
+		selected_ids,
+		className,
+		style,
+		default_width,
+		default_height,
+		render_node,
+		on_node_pointer_down,
+		on_drag_start,
+		on_drag,
+		on_drag_end,
+	} = props;
+	const { camera } = use_graph_camera();
+	const node_lookup = useMemo(() => new Map(nodes.map((node) => [node.id, node] as const)), [nodes]);
+	const drag_ref = useRef<Node_drag_state | null>(null);
+	const [dragging_ids, set_dragging_ids] = useState<Set<Node_id>>(() => new Set());
+	const resolved_render = render_node ?? default_render_node;
+	const resolved_width = default_width ?? DEFAULT_NODE_WIDTH;
+	const resolved_height = default_height ?? DEFAULT_NODE_HEIGHT;
+
+	const emit_drag_event = useCallback((phase: 'start' | 'move' | 'end', event: React_pointer_event<HTMLDivElement>) => {
+		const drag = drag_ref.current;
+		if (!drag) {
+			return;
+		}
+		const delta: Point = {
+			x: (event.clientX - drag.origin.x) / drag.scale,
+			y: (event.clientY - drag.origin.y) / drag.scale,
+		};
+		const positions = compute_drag_positions(drag.initial_positions, delta);
+		const nodes_snapshot = new Map<Node_id, Node<T>>();
+		for (const id of drag.target_ids) {
+			const current = node_lookup.get(id);
+			if (current) {
+				nodes_snapshot.set(id, current);
+			}
+		}
+		const payload: Graph_node_drag_event<T> = {
+			node_ids: [...positions.keys()],
+			positions,
+			delta,
+			nodes: nodes_snapshot,
+		};
+		if (phase === 'start') {
+			on_drag_start?.(payload);
+		} else if (phase === 'move') {
+			on_drag?.(payload);
+		} else {
+			on_drag_end?.(payload);
+		}
+	}, [node_lookup, on_drag_start, on_drag, on_drag_end]);
+
+	const end_drag = useCallback(() => {
+		drag_ref.current = null;
+		set_dragging_ids(new Set<Node_id>());
+	}, []);
+
+	const handle_pointer_down = useCallback((node: Node<T>, event: React_pointer_event<HTMLDivElement>) => {
+		if (event.button !== 0) {
+			return;
+		}
+		if (drag_ref.current) {
+			return;
+		}
+		event.preventDefault();
+		const selection = selected_ids;
+		let target_ids: Node_id[] = [];
+		if (selection?.has(node.id)) {
+			for (const id of selection) {
+				if (node_lookup.has(id)) {
+					target_ids.push(id);
+				}
+			}
+		}
+		if (!target_ids.length) {
+			if (node_lookup.has(node.id)) {
+				target_ids = [node.id];
+			}
+		}
+		const initial_positions = new Map<Node_id, Point>();
+		for (const id of target_ids) {
+			const current = node_lookup.get(id);
+			if (current) {
+				initial_positions.set(id, { x: current.x, y: current.y });
+			}
+		}
+		if (!initial_positions.size) {
+			return;
+		}
+		on_node_pointer_down?.({ node, pointer_event: event });
+		const capture_target = event.currentTarget as HTMLDivElement;
+		if (typeof capture_target.setPointerCapture === 'function') {
+			try {
+				capture_target.setPointerCapture(event.pointerId);
+			} catch {
+				// jsdom does not implement pointer capture
+			}
+		}
+		drag_ref.current = {
+			pointer_id: event.pointerId,
+			origin: { x: event.clientX, y: event.clientY },
+			initial_positions,
+			target_ids,
+			scale: camera.scale,
+		};
+		set_dragging_ids(new Set(initial_positions.keys()));
+		emit_drag_event('start', event);
+	}, [camera.scale, emit_drag_event, node_lookup, on_node_pointer_down, selected_ids]);
+
+	const handle_pointer_move = useCallback((event: React_pointer_event<HTMLDivElement>) => {
+		const drag = drag_ref.current;
+		if (!drag || drag.pointer_id !== event.pointerId) {
+			return;
+		}
+		event.preventDefault();
+		emit_drag_event('move', event);
+	}, [emit_drag_event]);
+
+	const handle_pointer_up = useCallback((event: React_pointer_event<HTMLDivElement>) => {
+		const drag = drag_ref.current;
+		if (!drag || drag.pointer_id !== event.pointerId) {
+			return;
+		}
+		if (typeof event.currentTarget.releasePointerCapture === 'function' && event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+			try {
+				event.currentTarget.releasePointerCapture(event.pointerId);
+			} catch {
+				// ignore missing pointer capture in non-DOM environments
+			}
+		}
+		emit_drag_event('end', event);
+		end_drag();
+	}, [emit_drag_event, end_drag]);
+
+	const handle_pointer_cancel = useCallback((event: React_pointer_event<HTMLDivElement>) => {
+		const drag = drag_ref.current;
+		if (!drag || drag.pointer_id !== event.pointerId) {
+			return;
+		}
+		emit_drag_event('end', event);
+		end_drag();
+	}, [emit_drag_event, end_drag]);
+
+	const layer_style: CSSProperties = {
+		position: 'absolute',
+		top: 0,
+		left: 0,
+		width: '100%',
+		height: '100%',
+		pointerEvents: 'none',
+		...style,
+	};
+
+	return (
+		<div className={className} style={layer_style}>
+			{nodes.map((node) => {
+				const width = node.w ?? resolved_width;
+				const height = node.h ?? resolved_height;
+				const is_selected = selected_ids?.has(node.id) ?? false;
+				const is_dragging = dragging_ids.has(node.id);
+				const node_style: CSSProperties = {
+					position: 'absolute',
+					left: node.x,
+					top: node.y,
+					width,
+					height,
+					cursor: is_dragging ? 'grabbing' : 'grab',
+					userSelect: 'none',
+					transform: 'translateZ(0)',
+					pointerEvents: 'auto',
+				};
+				return (
+					<div
+						key={node.id}
+						data-node-id={node.id}
+						style={node_style}
+						onPointerDown={(event) => handle_pointer_down(node, event)}
+						onPointerMove={handle_pointer_move}
+						onPointerUp={handle_pointer_up}
+						onPointerCancel={handle_pointer_cancel}
+					>
+						{resolved_render(node, { selected: is_selected, dragging: is_dragging })}
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/tests/camera.test.ts
+++ b/tests/camera.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+	DEFAULT_CAMERA_LIMITS,
+	DEFAULT_CAMERA_STATE,
+	clamp_scale,
+	pan_camera,
+	reset_camera,
+	zoom_camera,
+} from '../src/react/camera.js';
+
+describe('camera utilities', () => {
+	it('clamps scale within bounds', () => {
+		const limits = { min_scale: 0.5, max_scale: 2 } satisfies typeof DEFAULT_CAMERA_LIMITS;
+		expect(clamp_scale(0.1, limits)).toBe(0.5);
+		expect(clamp_scale(5, limits)).toBe(2);
+		expect(clamp_scale(1.5, limits)).toBe(1.5);
+	});
+
+	it('returns original camera when pan deltas are zero', () => {
+		const camera = { ...DEFAULT_CAMERA_STATE };
+		expect(pan_camera(camera, 0, 0)).toBe(camera);
+	});
+
+	it('offsets camera when panning', () => {
+		const camera = { ...DEFAULT_CAMERA_STATE };
+		const panned = pan_camera(camera, 10, -5);
+		expect(panned).not.toBe(camera);
+		expect(panned.x).toBe(10);
+		expect(panned.y).toBe(-5);
+		expect(panned.scale).toBe(camera.scale);
+	});
+
+	it('zooms relative to a pivot point', () => {
+		const camera = { x: 10, y: 20, scale: 1 } satisfies typeof DEFAULT_CAMERA_STATE;
+		const pivot = { x: 30, y: 40 };
+		const zoomed = zoom_camera(camera, 2, pivot, DEFAULT_CAMERA_LIMITS);
+		expect(zoomed.scale).toBeCloseTo(2);
+		const before_world = {
+			x: (pivot.x - camera.x) / camera.scale,
+			y: (pivot.y - camera.y) / camera.scale,
+		};
+		const after_world = {
+			x: (pivot.x - zoomed.x) / zoomed.scale,
+			y: (pivot.y - zoomed.y) / zoomed.scale,
+		};
+		expect(after_world.x).toBeCloseTo(before_world.x, 5);
+		expect(after_world.y).toBeCloseTo(before_world.y, 5);
+	});
+
+	it('resets to fallback camera state', () => {
+		const camera = { x: 5, y: 5, scale: 0.75 } satisfies typeof DEFAULT_CAMERA_STATE;
+		const fallback = { x: 1, y: 2, scale: 1 } satisfies typeof DEFAULT_CAMERA_STATE;
+		const reset = reset_camera(camera, fallback);
+		expect(reset).not.toBe(camera);
+		expect(reset).toEqual(fallback);
+	});
+});

--- a/tests/react-nodes.test.tsx
+++ b/tests/react-nodes.test.tsx
@@ -1,0 +1,131 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import type { Node } from '../src/core/types.js';
+import { Graph_canvas } from '../src/react/canvas.js';
+import { Graph_node_layer } from '../src/react/nodes.js';
+import type { Graph_node_drag_event } from '../src/react/nodes.js';
+
+const SAMPLE_NODES: Node[] = [
+	{
+		id: 'node-a',
+		type: 'Alpha',
+		x: 20,
+		y: 30,
+		ports: [],
+	},
+	{
+		id: 'node-b',
+		type: 'Beta',
+		x: 140,
+		y: 80,
+		ports: [],
+	},
+];
+
+describe('Graph_node_layer', () => {
+	test('renders nodes with the default surface', () => {
+		render(
+			<Graph_canvas>
+				<Graph_node_layer nodes={SAMPLE_NODES} />
+			</Graph_canvas>,
+		);
+		const alpha = screen.getByText('Alpha');
+		expect(alpha).toBeTruthy();
+		const beta = screen.getByText('Beta');
+		expect(beta).toBeTruthy();
+	});
+
+	test('emits drag updates for the selected node group', () => {
+		const on_drag = vi.fn();
+		const on_drag_start = vi.fn();
+		const on_drag_end = vi.fn();
+		const selected = new Set(['node-a', 'node-b']);
+		const { container } = render(
+		<Graph_canvas>
+		<Graph_node_layer
+		nodes={SAMPLE_NODES}
+		selected_ids={selected}
+		on_drag_start={on_drag_start}
+		on_drag={on_drag}
+		on_drag_end={on_drag_end}
+		/>
+		</Graph_canvas>,
+		);
+		const target = container.querySelector('[data-node-id="node-a"]') as HTMLElement;
+		Object.assign(target, {
+			setPointerCapture: vi.fn(),
+			releasePointerCapture: vi.fn(),
+			hasPointerCapture: () => false,
+		});
+		fireEvent.pointerDown(target, {
+			pointerId: 1,
+			clientX: 200,
+			clientY: 120,
+			button: 0,
+			buttons: 1,
+			bubbles: true,
+		});
+		fireEvent.pointerMove(target, {
+			pointerId: 1,
+			clientX: 218,
+			clientY: 148,
+			buttons: 1,
+			bubbles: true,
+		});
+		fireEvent.pointerUp(target, {
+			pointerId: 1,
+			clientX: 218,
+			clientY: 148,
+			button: 0,
+			buttons: 0,
+			bubbles: true,
+		});
+		expect(on_drag_start).toHaveBeenCalledTimes(1);
+		expect(on_drag).toHaveBeenCalled();
+		expect(on_drag_end).toHaveBeenCalledTimes(1);
+		const payload = on_drag.mock.calls.at(-1)?.[0] as Graph_node_drag_event | undefined;
+		expect(payload).toBeDefined();
+		if (!payload) {
+			throw new Error('expected drag payload');
+		}
+		expect(payload.delta).toEqual({ x: 18, y: 28 });
+		expect(payload.positions.get('node-a')).toEqual({ x: 38, y: 58 });
+		expect(payload.positions.get('node-b')).toEqual({ x: 158, y: 108 });
+	});
+
+	test('scales drag deltas according to the camera zoom', () => {
+		const on_drag = vi.fn();
+		const { container } = render(
+		<Graph_canvas initial_camera={{ scale: 2 }}>
+		<Graph_node_layer nodes={SAMPLE_NODES} on_drag={on_drag} />
+		</Graph_canvas>,
+		);
+		const target = container.querySelector('[data-node-id="node-a"]') as HTMLElement;
+		Object.assign(target, {
+			setPointerCapture: vi.fn(),
+			releasePointerCapture: vi.fn(),
+			hasPointerCapture: () => false,
+		});
+		fireEvent.pointerDown(target, {
+			pointerId: 5,
+			clientX: 100,
+			clientY: 100,
+			button: 0,
+			buttons: 1,
+			bubbles: true,
+		});
+		fireEvent.pointerMove(target, {
+			pointerId: 5,
+			clientX: 140,
+			clientY: 160,
+			buttons: 1,
+			bubbles: true,
+		});
+		const payload = on_drag.mock.calls.at(-1)?.[0] as Graph_node_drag_event | undefined;
+		expect(payload).toBeDefined();
+		if (!payload) {
+			throw new Error('expected drag payload');
+		}
+		expect(payload.delta).toEqual({ x: 20, y: 30 });
+	});
+});


### PR DESCRIPTION
## Summary
- add a Graph_node_layer component with a reusable compute_drag_positions helper for node dragging
- wire the layer into the camera context so multi-select drags emit start/move/end payloads
- cover the React node layer with Vitest suites that invoke pointer handlers and assert drag deltas

## Testing
- npx vitest run
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e543bb966083218532689f99654bef