### PR TITLE
Expose React node layer from the public API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from './core/history.js';
 export * from './core/selection.js';
 export * from './react/camera.js';
 export * from './react/canvas.js';
+export * from './react/nodes.js';

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import * as NovaNode from '../src/index.js';
+
+describe('public exports', () => {
+	it('exposes the react node layer helpers', () => {
+		expect(NovaNode.Graph_node_layer).toBeTypeOf('function');
+		expect(NovaNode.compute_drag_positions).toBeTypeOf('function');
+	});
+});


### PR DESCRIPTION
## Summary
- export the React node layer module from the package index so node dragging utilities are consumable
- add a regression test to ensure the node layer helpers remain part of the public surface

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e581a87c3c8321836f9c5c6b8dae2d