### PR TITLE
feat: promote docs-bot to gated PR workflow

### DIFF
--- a/.github/workflows/docs-bot.yaml
+++ b/.github/workflows/docs-bot.yaml
@@ -1,0 +1,31 @@
+name: docs-bot
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: '0 12 * * 1'
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+jobs:
+  lint_and_propose:
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request == null &&
+      contains(github.event.comment.body, '/docs update'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - name: install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: lint documentation
+        run: pnpm run lint
+      - name: open gated pull request
+        env:
+          DOCS_BOT_TOKEN: ${{ secrets.DOCS_BOT_TOKEN }}
+        run: node agents/scripts/open_pr_from_changes.mjs "docs-bot" "chore(docs-bot): automated fixes"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ With draggable node surfaces shipped, the focus shifts to **Ports & edge creatio
 
 Agent automation lives alongside the product roadmap. The next three initiatives keep the internal bots aligned with repository needs:
 
-* Promote `docs-bot` from suggestion-only comments to gated pull requests for documentation updates.
+* [x] Promote `docs-bot` from suggestion-only comments to gated pull requests for documentation updates (now ships gated PRs).
 * Extend `perf-profiler` with WebGL frame-time capture so large graph scenarios stay within targets.
 * Expand `layout-lab` to benchmark orthogonal versus force-directed routing strategies.
 

--- a/agents/contracts/docs-bot.yaml
+++ b/agents/contracts/docs-bot.yaml
@@ -1,0 +1,45 @@
+agent_id: docs-bot
+version: 1.1.0
+summary: "Lint documentation and open gated pull requests for updates."
+owners:
+  - "@docs-owners"
+triggers:
+  - type: issue_comment
+    command: "/docs update"
+  - type: schedule
+    cron: "0 12 * * 1"
+capabilities:
+  - lint_docs
+  - apply_fixes
+  - open_pull_request
+inputs:
+  - type: git_repository
+  - type: issue_comment
+outputs:
+  - type: pull_request
+  - type: artifact
+writes_allowed:
+  - path: "docs/**"
+  - path: "*.md"
+forbidden_paths:
+  - "src/**"
+  - "tests/**"
+review_policy:
+  mode: pr_required
+  reviewers:
+    - "@docs-owners"
+observability:
+  metrics:
+    - "docs_bot_prs_total"
+    - "docs_bot_lint_failures_total"
+  logs: "agents/artifacts/docs-bot/logs/%Y-%m-%d.jsonl"
+security:
+  permissions:
+    contents: write
+    pull-requests: write
+    issues: write
+  secrets:
+    - "DOCS_BOT_TOKEN"
+change_management:
+  semver_bump_requires:
+    - owners_approval

--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -1,0 +1,13 @@
+agents:
+  - agent_id: docs-bot
+    intent: "Lint documentation and raise gated pull requests"
+    triggers:
+      - type: issue_comment
+        command: "/docs update"
+      - type: schedule
+        cron: "0 12 * * 1"
+    writes:
+      - "docs/**"
+      - "*.md"
+    reviewers:
+      - "@docs-owners"

--- a/agents/scripts/open_pr_from_changes.mjs
+++ b/agents/scripts/open_pr_from_changes.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import {execSync} from 'node:child_process';
+import crypto from 'node:crypto';
+import process from 'node:process';
+
+const [agent_id, commit_message] = process.argv.slice(2);
+assert(agent_id, 'agent_id argument is required');
+assert(commit_message, 'commit message argument is required');
+
+const run = (command, options = {}) => {
+	const result = execSync(command, {encoding: 'utf8', stdio: ['pipe', 'pipe', 'inherit'], ...options});
+	return typeof result === 'string' ? result.trim() : '';
+};
+
+const status = run('git status --porcelain');
+if (!status) {
+	console.log(`[${agent_id}] no changes detected; nothing to commit`);
+	process.exit(0);
+}
+
+const tracked_files = status
+	.split('\n')
+	.filter(Boolean)
+	.map(line => line.slice(3).trim())
+	.filter(name => name && name !== '');
+
+const disallowed = tracked_files.filter(file_path => {
+	if (file_path.startsWith('docs/')) {
+		return false;
+	}
+	if (file_path.endsWith('.md')) {
+		return false;
+	}
+	return true;
+});
+
+assert.strictEqual(disallowed.length, 0, `docs-bot may not modify: ${disallowed.join(', ')}`);
+
+const branch_suffix = crypto.randomBytes(4).toString('hex');
+const branch_name = `agents/${agent_id}/${branch_suffix}`;
+const base_ref = process.env.GITHUB_BASE_REF || 'main';
+
+run(`git checkout -B ${branch_name}`);
+run('git config user.name "docs-bot"');
+run('git config user.email "docs-bot@users.noreply.github.com"');
+run('git add -A');
+run(`git commit -m "${commit_message}"`);
+
+const repository = process.env.GITHUB_REPOSITORY;
+const token = process.env.DOCS_BOT_TOKEN || process.env.GITHUB_TOKEN;
+
+if (repository && token) {
+	const remote_url = `https://${token}@github.com/${repository}.git`;
+	run(`git push ${remote_url} ${branch_name}:${branch_name}`);
+	console.log(`[${agent_id}] pushed branch ${branch_name}`);
+} else {
+	console.warn(`[${agent_id}] missing repository or token; skipping push`);
+}
+
+if (repository && token) {
+	const pr_title = `[agent:${agent_id}] ${commit_message}`;
+	const pr_body = [
+		'## Automated documentation update',
+		'- Source: docs-bot automation',
+		'- Reviewers: @docs-owners',
+		'',
+		'Please review the generated documentation updates before merging.'
+	].join('\n');
+
+	const response = await fetch(`https://api.github.com/repos/${repository}/pulls`, {
+		method: 'POST',
+		headers: {
+			'Authorization': `token ${token}`,
+			'Accept': 'application/vnd.github+json'
+		},
+		body: JSON.stringify({
+			title: pr_title,
+			head: branch_name,
+			base: base_ref,
+			body: pr_body,
+			draft: true
+		})
+	});
+
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(`failed to create pull request: ${response.status} ${text}`);
+	}
+
+	const pr = await response.json();
+	console.log(`[${agent_id}] opened PR #${pr.number}: ${pr.html_url}`);
+} else {
+	console.warn(`[${agent_id}] repository or token missing; PR not created`);
+}

--- a/agents/scripts/validate_contracts.mjs
+++ b/agents/scripts/validate_contracts.mjs
@@ -1,0 +1,16 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+
+const dir = path.resolve('agents/contracts');
+const files = fs.existsSync(dir) ? fs.readdirSync(dir).filter(file_name => file_name.endsWith('.yaml')) : [];
+
+assert(files.length > 0, 'no contract files found');
+
+for (const file_name of files) {
+	const raw = fs.readFileSync(path.join(dir, file_name), 'utf8');
+	assert(raw.includes('agent_id:'), `missing agent_id in ${file_name}`);
+	assert(raw.includes('triggers:'), `missing triggers in ${file_name}`);
+	assert(raw.includes('writes_allowed:'), `missing writes_allowed in ${file_name}`);
+	console.log('ok', file_name);
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
 		"build": "tsup",
 		"dev": "vite examples/react-vite-demo",
 		"lint": "eslint \"src/**/*.{ts,tsx}\"",
-		"test": "vitest"
+		"test": "vitest",
+		"agents:validate": "node agents/scripts/validate_contracts.mjs"
 	},
 	"keywords": [
 		"node-editor",


### PR DESCRIPTION
## Summary
- add docs-bot to the agent registry with a contract that documents the gated PR workflow
- add a reusable script and GitHub Actions workflow that lint documentation and open draft PRs for review
- expose an `agents:validate` helper and mark the automation roadmap item as complete in the README

## Testing
- npm test -- --run
- node agents/scripts/validate_contracts.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e58a1c6e848321a3b29d859ff473e2